### PR TITLE
Feat/#2 로그인 기능구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'
+
+    // session redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.session:spring-session-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/jjabtwitter/global/exception/BusinessLogicException.java
+++ b/src/main/java/jjabtwitter/global/exception/BusinessLogicException.java
@@ -1,0 +1,20 @@
+package jjabtwitter.global.exception;
+
+public class BusinessLogicException extends RuntimeException{
+
+    private final ExceptionInformation exceptionInformation;
+
+    public BusinessLogicException(ExceptionInformation exceptionInformation) {
+        super();
+        this.exceptionInformation = exceptionInformation;
+    }
+
+    public int getCode() {
+        return exceptionInformation.getCode();
+    }
+
+    @Override
+    public String getMessage() {
+        return exceptionInformation.getMessage();
+    }
+}

--- a/src/main/java/jjabtwitter/global/exception/ExceptionInformation.java
+++ b/src/main/java/jjabtwitter/global/exception/ExceptionInformation.java
@@ -12,13 +12,14 @@ public enum ExceptionInformation {
 
     // 클래스이름_필드명_틀린내용
     // 2___: 회원 관련
-    MEMBER_ID_NOT_FOUND(2000, "존재하지 않는 회원입니다."),
+    MEMBER_NOT_FOUND(2000, "존재하지 않는 회원입니다."),
     MEMBER_PASSWORD_INVALID(2001, "회원 비밀번호가 잘못되었습니다."),
     MEMBER_NICKNAME_INVALID(2002, "회원 닉네임이 잘못되었습니다."),
     MEMBER_CUSTOM_ID_DUPLICATE(2003, "이미 존재하는 아이디입니다."),
     MEMBER_IS_DELETED(2004, "삭제된 회원입니다."),
 
-    PASSWORD_ENCRYPT_FAIL(2500, "비밀번호 암호화에 실패했습니다.");
+    PASSWORD_ENCRYPT_FAIL(2500, "비밀번호 암호화에 실패했습니다."),
+    LOGIN_FAIL(2501, "로그인에 실패하였습니다.");
 
     private int code;
 

--- a/src/main/java/jjabtwitter/global/exception/ExceptionInformation.java
+++ b/src/main/java/jjabtwitter/global/exception/ExceptionInformation.java
@@ -16,7 +16,9 @@ public enum ExceptionInformation {
     MEMBER_PASSWORD_INVALID(2001, "회원 비밀번호가 잘못되었습니다."),
     MEMBER_NICKNAME_INVALID(2002, "회원 닉네임이 잘못되었습니다."),
     MEMBER_CUSTOM_ID_DUPLICATE(2003, "이미 존재하는 아이디입니다."),
-    MEMBER_IS_DELETED(2004, "삭제된 회원입니다.");
+    MEMBER_IS_DELETED(2004, "삭제된 회원입니다."),
+
+    PASSWORD_ENCRYPT_FAIL(2500, "비밀번호 암호화에 실패했습니다.");
 
     private int code;
 

--- a/src/main/java/jjabtwitter/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/jjabtwitter/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.EnumMap;
 
+import static jjabtwitter.global.exception.ExceptionInformation.*;
+import static org.springframework.http.HttpStatus.*;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 
 @Slf4j
@@ -18,6 +20,7 @@ public class GlobalExceptionHandler {
             ExceptionInformation.class);
 
     public GlobalExceptionHandler() {
+        exceptionInfoToHttpStatus.put(LOGIN_FAIL, UNAUTHORIZED);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/jjabtwitter/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/jjabtwitter/global/exception/GlobalExceptionHandler.java
@@ -38,4 +38,11 @@ public class GlobalExceptionHandler {
                 .body(exceptionResponse);
     }
 
+    @ExceptionHandler(BusinessLogicException.class)
+    public ResponseEntity<ExceptionResponse> handlerBusinessLogicException(final BusinessLogicException e) {
+        final ExceptionResponse exceptionResponse = new ExceptionResponse(e.getCode(), e.getMessage());
+
+        return ResponseEntity.internalServerError()
+                .body(exceptionResponse);
+    }
 }

--- a/src/main/java/jjabtwitter/member/application/MemberService.java
+++ b/src/main/java/jjabtwitter/member/application/MemberService.java
@@ -1,15 +1,19 @@
 package jjabtwitter.member.application;
 
 import jjabtwitter.global.exception.ClientException;
-import jjabtwitter.global.exception.ExceptionInformation;
 import jjabtwitter.member.application.dto.JoinRequest;
+import jjabtwitter.member.application.dto.LoginRequest;
 import jjabtwitter.member.domain.CustomId;
 import jjabtwitter.member.domain.Member;
+import jjabtwitter.member.domain.Password;
 import jjabtwitter.member.domain.PasswordEncoder;
 import jjabtwitter.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import static jjabtwitter.global.exception.ExceptionInformation.LOGIN_FAIL;
+import static jjabtwitter.global.exception.ExceptionInformation.MEMBER_CUSTOM_ID_DUPLICATE;
 
 @RequiredArgsConstructor
 @Transactional
@@ -35,7 +39,15 @@ public class MemberService {
 
     private void validateIsIdDuplicated(final String customId) {
         if (memberRepository.existsByCustomId(CustomId.create(customId))) {
-            throw new ClientException(ExceptionInformation.MEMBER_CUSTOM_ID_DUPLICATE);
+            throw new ClientException(MEMBER_CUSTOM_ID_DUPLICATE);
         }
+    }
+
+    public Member login(final LoginRequest loginRequest) {
+        final CustomId customId = CustomId.create(loginRequest.customId());
+        final Password password = Password.create(loginRequest.password());
+        password.encrypt(passwordEncoder);
+        return memberRepository.findByCustomIdAndPassword(customId, password)
+                .orElseThrow(() -> new ClientException(LOGIN_FAIL));
     }
 }

--- a/src/main/java/jjabtwitter/member/application/MemberService.java
+++ b/src/main/java/jjabtwitter/member/application/MemberService.java
@@ -5,6 +5,7 @@ import jjabtwitter.global.exception.ExceptionInformation;
 import jjabtwitter.member.application.dto.JoinRequest;
 import jjabtwitter.member.domain.CustomId;
 import jjabtwitter.member.domain.Member;
+import jjabtwitter.member.domain.PasswordEncoder;
 import jjabtwitter.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
 
+    private final PasswordEncoder passwordEncoder;
+
     public Member joinMember(final JoinRequest joinRequest) {
         final Member member = Member.create(
                 joinRequest.customId(),
@@ -25,6 +28,8 @@ public class MemberService {
         );
 
         validateIsIdDuplicated(joinRequest.customId());
+        member.encrypt(passwordEncoder);
+
         return memberRepository.save(member);
     }
 

--- a/src/main/java/jjabtwitter/member/application/dto/LoginRequest.java
+++ b/src/main/java/jjabtwitter/member/application/dto/LoginRequest.java
@@ -1,0 +1,4 @@
+package jjabtwitter.member.application.dto;
+
+public record LoginRequest(String customId, String password) {
+}

--- a/src/main/java/jjabtwitter/member/domain/LoginInfo.java
+++ b/src/main/java/jjabtwitter/member/domain/LoginInfo.java
@@ -1,0 +1,19 @@
+package jjabtwitter.member.domain;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LoginInfo implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    private final List<Long> ids;
+    private int representativeIndex;
+
+    public LoginInfo(final Long customId) {
+        this.ids = new ArrayList<>();
+        ids.add(customId);
+        representativeIndex = 0;
+    }
+}

--- a/src/main/java/jjabtwitter/member/domain/Member.java
+++ b/src/main/java/jjabtwitter/member/domain/Member.java
@@ -50,4 +50,8 @@ public class Member extends TemporalRecord {
     public String getProfileImageInfo() {
         return profileImageInfo;
     }
+
+    public void encrypt(final PasswordEncoder passwordEncoder) {
+        password.encrypt(passwordEncoder);
+    }
 }

--- a/src/main/java/jjabtwitter/member/domain/Member.java
+++ b/src/main/java/jjabtwitter/member/domain/Member.java
@@ -39,6 +39,10 @@ public class Member extends TemporalRecord {
         return new Member(CustomId.create(customId), nickName, Password.create(password));
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public String getCustomId() {
         return customId.getValue();
     }

--- a/src/main/java/jjabtwitter/member/domain/Password.java
+++ b/src/main/java/jjabtwitter/member/domain/Password.java
@@ -8,16 +8,10 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 
-import java.util.Objects;
-import java.util.regex.Pattern;
-
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class Password {
-
-    private static final String PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,30}$";
-    private static final Pattern passwordPattern = Pattern.compile(PASSWORD_PATTERN);
 
     @Column(name = "password", nullable = false)
     private String value;
@@ -27,16 +21,13 @@ public class Password {
     }
 
     public static Password create(final String value) {
-        if (isValidPassword(value)) {
+        if (PasswordValidator.isValidPassword(value)) {
             return new Password(value);
         }
         throw new ClientException(ExceptionInformation.MEMBER_PASSWORD_INVALID);
     }
 
-    private static boolean isValidPassword(final String value) {
-        if (Objects.isNull(value) || value.isBlank()) {
-            return false;
-        }
-        return passwordPattern.matcher(value).matches();
+    public void encrypt(final PasswordEncoder passwordEncoder) {
+        this.value = passwordEncoder.encode(value);
     }
 }

--- a/src/main/java/jjabtwitter/member/domain/PasswordEncoder.java
+++ b/src/main/java/jjabtwitter/member/domain/PasswordEncoder.java
@@ -1,0 +1,44 @@
+package jjabtwitter.member.domain;
+
+import jjabtwitter.global.exception.BusinessLogicException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+import static jjabtwitter.global.exception.ExceptionInformation.PASSWORD_ENCRYPT_FAIL;
+
+@RequiredArgsConstructor
+@Component
+public class PasswordEncoder {
+    private static final String SHA_256 = "SHA-256";
+
+    @Value("${salt.en1}")
+    private String salt1;
+
+    @Value("${salt.en2}")
+    private String salt2;
+
+    public String encode(final String password) {
+        try {
+            final String salted = saltAndEncrypt(password, salt1);
+            return saltAndEncrypt(salted, salt2);
+        } catch (NoSuchAlgorithmException e) {
+            throw new BusinessLogicException(PASSWORD_ENCRYPT_FAIL);
+        }
+    }
+
+    private String saltAndEncrypt(final String password, final String salt) throws NoSuchAlgorithmException {
+        MessageDigest md = MessageDigest.getInstance(SHA_256);
+        final String salted = password + salt;
+        md.update(salted.getBytes());
+
+        final StringBuilder sb = new StringBuilder();
+        for (byte b : md.digest()) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/jjabtwitter/member/domain/PasswordValidator.java
+++ b/src/main/java/jjabtwitter/member/domain/PasswordValidator.java
@@ -1,0 +1,20 @@
+package jjabtwitter.member.domain;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class PasswordValidator {
+    private static final String PASSWORD_PATTERN = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,30}$";
+    private static final Pattern passwordPattern = Pattern.compile(PASSWORD_PATTERN);
+
+    static boolean isValidPassword(final String value) {
+        if (Objects.isNull(value) || value.isBlank()) {
+            return false;
+        }
+        return passwordPattern.matcher(value).matches();
+    }
+}

--- a/src/main/java/jjabtwitter/member/repository/MemberRepository.java
+++ b/src/main/java/jjabtwitter/member/repository/MemberRepository.java
@@ -2,9 +2,14 @@ package jjabtwitter.member.repository;
 
 import jjabtwitter.member.domain.CustomId;
 import jjabtwitter.member.domain.Member;
+import jjabtwitter.member.domain.Password;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByCustomId(CustomId customId);
+
+    Optional<Member> findByCustomIdAndPassword(CustomId customId, Password password);
 }

--- a/src/main/java/jjabtwitter/member/ui/MemberController.java
+++ b/src/main/java/jjabtwitter/member/ui/MemberController.java
@@ -1,7 +1,11 @@
 package jjabtwitter.member.ui;
 
+import jakarta.servlet.http.HttpSession;
 import jjabtwitter.member.application.MemberService;
 import jjabtwitter.member.application.dto.JoinRequest;
+import jjabtwitter.member.application.dto.LoginRequest;
+import jjabtwitter.member.domain.LoginInfo;
+import jjabtwitter.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -20,5 +24,15 @@ public class MemberController {
     public ResponseEntity<Void> join(@RequestBody final JoinRequest joinRequest) {
         memberService.joinMember(joinRequest);
         return ResponseEntity.created(URI.create("/login")).build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(@RequestBody final LoginRequest loginRequest, final HttpSession httpSession) {
+
+        final Member member = memberService.login(loginRequest);
+        httpSession.setAttribute("loginIfo", new LoginInfo(member.getId()));
+        httpSession.setMaxInactiveInterval(10000);
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,19 +1,7 @@
 spring:
-  datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL
-    driver-class-name: org.h2.Driver
-    username: sa
-    password: password
-  h2:
-    console:
-      enabled: true
-  jpa:
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQL8Dialect
-        format_sql: true
-    show-sql: true
-
-logging:
-  level:
-    org.hibernate.orm.jdbc.bind: trace
+  application:
+    name: local
+  profiles:
+    active: local
+  config:
+    import: classpath:/local.yml

--- a/src/main/resources/local.yml
+++ b/src/main/resources/local.yml
@@ -1,0 +1,23 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=MySQL
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: password
+  h2:
+    console:
+      enabled: true
+  jpa:
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.MySQL8Dialect
+        format_sql: true
+    show-sql: true
+
+logging:
+  level:
+    org.hibernate.orm.jdbc.bind: trace
+
+salt:
+  en1: locals1
+  en2: localS2

--- a/src/main/resources/local.yml
+++ b/src/main/resources/local.yml
@@ -13,6 +13,21 @@ spring:
         dialect: org.hibernate.dialect.MySQL8Dialect
         format_sql: true
     show-sql: true
+  session:
+    store-type: redis
+    redis:
+      namespace: jjabtwit-session
+  data:
+    redis:
+      host: localhost
+      password: 1234
+      port: 6379
+
+server:
+  servlet:
+    session:
+      cookie:
+        name: JSESSIONID
 
 logging:
   level:
@@ -21,3 +36,4 @@ logging:
 salt:
   en1: locals1
   en2: localS2
+

--- a/src/test/java/jjabtwitter/member/application/MemberServiceTest.java
+++ b/src/test/java/jjabtwitter/member/application/MemberServiceTest.java
@@ -4,8 +4,10 @@ import jjabtwitter.IntegrationTest;
 import jjabtwitter.global.exception.ClientException;
 import jjabtwitter.member.application.dto.JoinRequest;
 import jjabtwitter.member.domain.Member;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @IntegrationTest
 class MemberServiceTest {
@@ -21,8 +23,7 @@ class MemberServiceTest {
         final JoinRequest joinRequest = new JoinRequest("customId", "password1!", "nickname");
         final Member member = memberService.joinMember(joinRequest);
 
-        Assertions.assertThat(member.getCustomId()).isEqualTo("customId");
-
+        assertThat(member.getCustomId()).isEqualTo("customId");
     }
 
     @Test
@@ -30,7 +31,7 @@ class MemberServiceTest {
         final JoinRequest joinRequest = new JoinRequest("customId", "password1!", "nickname");
         memberService.joinMember(joinRequest);
 
-        Assertions.assertThatThrownBy(() -> memberService.joinMember(joinRequest))
+        assertThatThrownBy(() -> memberService.joinMember(joinRequest))
                 .isExactlyInstanceOf(ClientException.class);
     }
 

--- a/src/test/java/jjabtwitter/member/application/MemberServiceTest.java
+++ b/src/test/java/jjabtwitter/member/application/MemberServiceTest.java
@@ -34,4 +34,6 @@ class MemberServiceTest {
                 .isExactlyInstanceOf(ClientException.class);
     }
 
+    // TODO: 비밀번호 암호화 해서 저장되는 것도 테스트 해야할지...
+
 }

--- a/src/test/java/jjabtwitter/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/jjabtwitter/member/integration/MemberIntegrationTest.java
@@ -1,11 +1,17 @@
 package jjabtwitter.member.integration;
 
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import jjabtwitter.IntegrationFixture;
 import jjabtwitter.member.application.dto.JoinRequest;
+import jjabtwitter.member.application.dto.LoginRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.List;
 
 import static jjabtwitter.global.exception.ExceptionInformation.MEMBER_CUSTOM_ID_DUPLICATE;
 import static jjabtwitter.global.exception.ExceptionInformation.MEMBER_NICKNAME_INVALID;
@@ -47,5 +53,54 @@ class MemberIntegrationTest extends IntegrationFixture {
                     assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
                     assertThat(response.jsonPath().get("errorCode").equals(MEMBER_CUSTOM_ID_DUPLICATE.getCode())).isTrue();
                 });
+    }
+
+    @Test
+    void 정상_로그인_200() {
+        // given
+        회원가입(new JoinRequest("customId", "password123$", "nickname"));
+        final LoginRequest loginRequest = new LoginRequest("customId", "password123$");
+
+        // when
+        final ExtractableResponse<Response> response = RestAssured
+                .given()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(loginRequest)
+                .when()
+                .post("/login")
+                .then()
+                .log().all()
+                .extract();
+
+        // then
+        assertSoftly(
+                SoftAssertions -> {
+                    assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+                    assertThat(response.header("Set-Cookie")).contains("JSESSIONID");
+                });
+//
+//        List<Header> cookies = response.headers().getList("Set-Cookie");
+//
+//        // JSESSIONID 값을 저장할 변수
+//        String jsessionId = "";
+//
+//        // 모든 쿠키를 확인하면서 JSESSIONID를 찾음
+//        for (Header cookie : cookies) {
+//            if (cookie.getValue().contains("JSESSIONID")) {
+//                // JSESSIONID를 가져옴
+//                jsessionId = cookie.getValue().split(";")[0].split("=")[1];
+//                break;
+//            }
+//        }
+//
+//        RestAssured
+//                .given()
+//                .log().all()
+//                .header("Cookie", jsessionId)
+//                .when()
+//                .get("/yaya")
+//                .then()
+//                .log().all()
+//                .extract();
     }
 }


### PR DESCRIPTION
- close : #2 

---

 1. 회원 가입시에 비밀번호를 암호화 해서 저장하도록 하고, 로그인시 이를 활용하여 로그인 하도록 한다 
 - sha-256 알고리즘으로 해싱 
 - salt 키를 두개 이용하여 해싱시에 같이 사용하도록 함


2. 인가정보를 session에 저장하도록 한다. 
 - spring session 을 사용하여 session정보를 redis에 저장하여 세션 클러스터링을 할 수 있도록 한다. 
 
---

차후 구현, 고려해야 하는 부분

- [ ] Oauth 구현 하기 (이거 할람 ssl 인증서 받야아하나?)
- [ ] 세션 정보를 AES를 이용하여 암호화 하여 저장하도록 한다. 