### PR TITLE
Fix/#11 멤버 도메인 예외처리 하기, CORS 수정하기 

### DIFF
--- a/src/main/java/jjabtwitter/global/config/CorsConfig.java
+++ b/src/main/java/jjabtwitter/global/config/CorsConfig.java
@@ -13,7 +13,10 @@ public class CorsConfig {
         return new WebMvcConfigurer() {
             @Override
             public void addCorsMappings(final CorsRegistry registry) {
-                registry.addMapping("/**").allowedOrigins("http://localhost:3000");
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "DELETE")
+                        .allowCredentials(true);
             }
         };
     }

--- a/src/main/java/jjabtwitter/global/exception/ExceptionInformation.java
+++ b/src/main/java/jjabtwitter/global/exception/ExceptionInformation.java
@@ -15,8 +15,9 @@ public enum ExceptionInformation {
     MEMBER_NOT_FOUND(2000, "존재하지 않는 회원입니다."),
     MEMBER_PASSWORD_INVALID(2001, "회원 비밀번호가 잘못되었습니다."),
     MEMBER_NICKNAME_INVALID(2002, "회원 닉네임이 잘못되었습니다."),
-    MEMBER_CUSTOM_ID_DUPLICATE(2003, "이미 존재하는 아이디입니다."),
-    MEMBER_IS_DELETED(2004, "삭제된 회원입니다."),
+    MEMBER_CUSTOM_ID_INVALID(2003, "회원 아이디가 잘못되었습니다."),
+    MEMBER_CUSTOM_ID_DUPLICATE(2004, "이미 존재하는 아이디입니다."),
+    MEMBER_IS_DELETED(2005, "삭제된 회원입니다."),
 
     PASSWORD_ENCRYPT_FAIL(2500, "비밀번호 암호화에 실패했습니다."),
     LOGIN_FAIL(2501, "로그인 정보가 일치하지 않습니다."),

--- a/src/main/java/jjabtwitter/member/domain/CustomId.java
+++ b/src/main/java/jjabtwitter/member/domain/CustomId.java
@@ -30,7 +30,7 @@ public class CustomId {
 
     private static void validate(final String customId) {
         if (Strings.isBlank(customId) || customId.length() > MAX_ID_LENGTH || customId.length() < MIN_ID_LENGTH) {
-            throw new ClientException(ExceptionInformation.MEMBER_NICKNAME_INVALID);
+            throw new ClientException(ExceptionInformation.MEMBER_CUSTOM_ID_INVALID);
         }
     }
 

--- a/src/main/java/jjabtwitter/member/domain/Member.java
+++ b/src/main/java/jjabtwitter/member/domain/Member.java
@@ -2,9 +2,13 @@ package jjabtwitter.member.domain;
 
 import jakarta.persistence.*;
 import jjabtwitter.global.domain.TemporalRecord;
+import jjabtwitter.global.exception.ClientException;
+import jjabtwitter.global.exception.ExceptionInformation;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
+
+import java.util.Objects;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(uniqueConstraints = {@UniqueConstraint(name = "uk_custom_id", columnNames = {"customId"})})
@@ -36,6 +40,9 @@ public class Member extends TemporalRecord {
     }
 
     public static Member create(final String customId, final String nickName, final String password) {
+        if (Objects.isNull(nickName) || nickName.isBlank() || nickName.length() < 1 || nickName.length() > 30) {
+            throw new ClientException(ExceptionInformation.MEMBER_NICKNAME_INVALID);
+        }
         return new Member(CustomId.create(customId), nickName, Password.create(password));
     }
 

--- a/src/test/java/jjabtwitter/member/integration/MemberIntegrationTest.java
+++ b/src/test/java/jjabtwitter/member/integration/MemberIntegrationTest.java
@@ -23,8 +23,20 @@ class MemberIntegrationTest extends IntegrationFixture {
     }
 
     @Test
-    void 회원가입_닉네임_예외_400() {
+    void 회원가입_아이디_예외_400() {
         final ExtractableResponse<Response> response = 회원가입("c", "password123$", "nickname");
+
+        assertSoftly(
+                SoftAssertions -> {
+                    assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+                    assertThat(response.jsonPath().getInt("errorCode")).isEqualTo(MEMBER_CUSTOM_ID_INVALID.getCode());
+
+                });
+    }
+
+    @Test
+    void 회원가입_닉네임_예외_400() {
+        final ExtractableResponse<Response> response = 회원가입("customId", "password123$", "");
 
         assertSoftly(
                 SoftAssertions -> {


### PR DESCRIPTION
- close : #11 

 멤버 도메인에 customId와 nickname validation 정확하게 나누고, 예외처리 함
 cors 설정에 메서드 설정 안해서 post 시 session정보 안넘어오는 것 수정함